### PR TITLE
Update create argument to match expected for FilesystemIterator

### DIFF
--- a/src/Reader/FileReader.php
+++ b/src/Reader/FileReader.php
@@ -44,7 +44,7 @@ class FileReader
 
         try {
             $dir = $this->filesystemIteratorFactory->create([
-                'path' => DirectoryList::MEDIA . DIRECTORY_SEPARATOR . $this->destination,
+                'directory' => DirectoryList::MEDIA . DIRECTORY_SEPARATOR . $this->destination,
                 'flags' => FilesystemIterator::SKIP_DOTS,
             ]);
         } catch (\UnexpectedValueException $exception) {


### PR DESCRIPTION
The argument expected is $directory, so path will throw an error on the admin page: 
![image](https://github.com/user-attachments/assets/89eb2f93-ada5-4c10-9c91-bffc4649b5eb)


![image](https://github.com/user-attachments/assets/593a4a59-464c-4ada-b1ae-00ade5ef5c15)
